### PR TITLE
add shortcuts for quick query comparisons

### DIFF
--- a/src/components/explorer/results/QueryThemesResultsContainer.js
+++ b/src/components/explorer/results/QueryThemesResultsContainer.js
@@ -12,7 +12,7 @@ import { postToDownloadUrl, downloadExplorerSvg, COVERAGE_REQUIRED } from '../..
 import messages from '../../../resources/messages';
 import withQueryResults from './QueryResultsSelector';
 import { TAG_SET_NYT_THEMES } from '../../../lib/tagUtil';
-import mapD3Top10Colors from '../../../lib/colorUtil';
+import { mapD3Top10Colors } from '../../../lib/colorUtil';
 import BubbleRowChart from '../../vis/BubbleRowChart';
 
 const BUBBLE_CHART_DOM_ID = 'explorer-nyt-theme-chart';

--- a/src/components/topic/snapshots/foci/builder/mediaType/MediaTypeStoryCountsPreviewContainer.js
+++ b/src/components/topic/snapshots/foci/builder/mediaType/MediaTypeStoryCountsPreviewContainer.js
@@ -6,7 +6,7 @@ import withAsyncData from '../../../../../common/hocs/AsyncDataContainer';
 import { fetchCreateFocusMediaTypeStoryCounts } from '../../../../../../actions/topicActions';
 import DataCard from '../../../../../common/DataCard';
 import BubbleRowChart from '../../../../../vis/BubbleRowChart';
-import mapD3Top10Colors from '../../../../../../lib/colorUtil';
+import { mapD3Top10Colors } from '../../../../../../lib/colorUtil';
 
 const BUBBLE_CHART_DOM_ID = 'focalSetCreatePreviewTopCountriesStoriesCounts';
 

--- a/src/components/topic/snapshots/foci/builder/nyttheme/NytThemeStoryCountsPreviewContainer.js
+++ b/src/components/topic/snapshots/foci/builder/nyttheme/NytThemeStoryCountsPreviewContainer.js
@@ -6,7 +6,7 @@ import withAsyncData from '../../../../../common/hocs/AsyncDataContainer';
 import { fetchCreateFocusNytThemeStoryCounts } from '../../../../../../actions/topicActions';
 import DataCard from '../../../../../common/DataCard';
 import PackedBubbleChart from '../../../../../vis/PackedBubbleChart';
-import mapD3Top10Colors from '../../../../../../lib/colorUtil';
+import { mapD3Top10Colors } from '../../../../../../lib/colorUtil';
 
 const BUBBLE_CHART_DOM_ID = 'focalSetCreatePreviewNytThemesCounts';
 

--- a/src/components/topic/snapshots/foci/builder/partisanship/PartisanshipStoryCountsPreviewContainer.js
+++ b/src/components/topic/snapshots/foci/builder/partisanship/PartisanshipStoryCountsPreviewContainer.js
@@ -6,9 +6,7 @@ import withAsyncData from '../../../../../common/hocs/AsyncDataContainer';
 import { fetchCreateFocusRetweetStoryCounts } from '../../../../../../actions/topicActions';
 import DataCard from '../../../../../common/DataCard';
 import BubbleRowChart from '../../../../../vis/BubbleRowChart';
-
-// @see http://colorbrewer2.org/#type=diverging&scheme=RdBu&n=5
-const PARTISANSHIP_COLORS = ['#0571b0', '#92c5de', '#666666', '#f4a582', '#ca0020'];
+import { PARTISANSHIP_COLORS } from '../../../../../../lib/colorUtil';
 
 export function usPartisanshipColorFor(name) {
   if (name.toLowerCase() === 'left') return PARTISANSHIP_COLORS[0];

--- a/src/components/topic/snapshots/foci/builder/topCountries/TopCountriesStoryCountsPreviewContainer.js
+++ b/src/components/topic/snapshots/foci/builder/topCountries/TopCountriesStoryCountsPreviewContainer.js
@@ -6,7 +6,7 @@ import withAsyncData from '../../../../../common/hocs/AsyncDataContainer';
 import { fetchCreateFocusTopCountriesStoryCounts } from '../../../../../../actions/topicActions';
 import DataCard from '../../../../../common/DataCard';
 import PackedBubbleChart from '../../../../../vis/PackedBubbleChart';
-import mapD3Top10Colors from '../../../../../../lib/colorUtil';
+import { mapD3Top10Colors } from '../../../../../../lib/colorUtil';
 
 const BUBBLE_CHART_DOM_ID = 'focalSetCreatePreviewTopCountriesStoriesCounts';
 

--- a/src/lib/colorUtil.js
+++ b/src/lib/colorUtil.js
@@ -1,7 +1,9 @@
 import * as d3 from 'd3';
 
+// @see http://colorbrewer2.org/#type=diverging&scheme=RdBu&n=5
+export const PARTISANSHIP_COLORS = ['#0571b0', '#92c5de', '#666666', '#f4a582', '#ca0020'];
 
-export default function mapD3Top10Colors(idx) {
+export function mapD3Top10Colors(idx) {
   if (idx <= -1) return 0;
   return d3.schemeCategory10[idx % 10];
 }


### PR DESCRIPTION
This implements an idea we discussed on a call - to allow quick comparisons of explorer queries across US political collections or years. I think this will help a lot in my teaching, and for demos to reveal some of the possible axes of comparative analysis. Also this sets up a generic approach to adding more items to this menu, based on researcher needs.

New 3-dot menu next to "Add Query" in Explorer opens the menu with 2 options (for now):
![Search___Explorer___Media_Cloud](https://user-images.githubusercontent.com/673178/97922744-f4556080-1d2a-11eb-83b3-9111b40e5fd4.jpg)

Picking either pops up an appropriate confirmation dialog:
![Search___Explorer___Media_Cloud](https://user-images.githubusercontent.com/673178/97922817-0d5e1180-1d2b-11eb-8e66-ef93734b7988.jpg)

Clicking "OK" replaces the queries as described and runs the queries right away:
![Search___Explorer___Media_Cloud](https://user-images.githubusercontent.com/673178/97922874-1ea71e00-1d2b-11eb-8a1a-4afa42242aab.jpg)
![Search___Explorer___Media_Cloud](https://user-images.githubusercontent.com/673178/97922970-4ac29f00-1d2b-11eb-8ca6-06e7048d635c.jpg)

Notes:
* This is implemented via the URL, not via pushing the new queries to state (because that seemed easier to me). I thought that would make the back button work better, but it doesn't :-( Ideas on a better approach? (see `handleReplaceQueries` for this code).
* This `QueryPickerContainer` is doing a *lot* and is quite hard to read and pull apart. I didn't see an obvious path to isolating this behavior in a sub-component that would avoid adding more complexity here :-( Open to suggestions on how to model that better,  but I also would love to have this deployed soon so I can use it in class!