### PR TITLE
Allow use of different mediacloud api backends

### DIFF
--- a/config/app.config.template
+++ b/config/app.config.template
@@ -25,6 +25,9 @@ SMTP_PASS = my_passowrd
 # Service: API Key for accessing Media Cloud (get this on your profile page)
 MEDIA_CLOUD_API_KEY = YOUR_MEDIACLOUD_API_KEY_HERE
 
+# Service: URL to mediacloud api (Media Cloud backend)
+MEDIA_CLOUD_API_URL = YOUR_MEDIACLOUD_API_URL
+
 # Service: URL to Mongo db to use for storing user-specific information (shared across apps)
 MONGO_URL = mongodb://localhost:27017/mediacloud-app
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -66,7 +66,10 @@ except ConfigException as e:
 TOOL_API_KEY = config.get('MEDIA_CLOUD_API_KEY')
 
 mc = mediacloud.api.AdminMediaCloud(TOOL_API_KEY)
-mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+try:
+    mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+except KeyError:
+    pass # just use the default API url because a custom one is not defined
 logger.info("Connected to mediacloud")
 
 # Connect to CLIFF if the settings are there

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -66,6 +66,7 @@ except ConfigException as e:
 TOOL_API_KEY = config.get('MEDIA_CLOUD_API_KEY')
 
 mc = mediacloud.api.AdminMediaCloud(TOOL_API_KEY)
+mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
 logger.info("Connected to mediacloud")
 
 # Connect to CLIFF if the settings are there

--- a/server/auth.py
+++ b/server/auth.py
@@ -146,7 +146,10 @@ def user_admin_mediacloud_client(user_mc_key=None):
     if mc_key_to_use is None:
         mc_key_to_use = user_mediacloud_key()
     user_mc = mediacloud.api.AdminMediaCloud(mc_key_to_use)
-    user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+    try:
+        user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+    except KeyError:
+        pass # just use the default API url because a custom one is not defined
     return user_mc
 
 
@@ -157,5 +160,8 @@ def user_mediacloud_client(user_mc_key=None):
     if mc_key_to_use is None:
         mc_key_to_use = user_mediacloud_key()
     user_mc = mediacloud.api.MediaCloud(mc_key_to_use)
-    user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+    try:
+        user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+    except KeyError:
+        pass # just use the default API url because a custom one is not defined
     return user_mc

--- a/server/auth.py
+++ b/server/auth.py
@@ -5,6 +5,7 @@ import mediacloud.api
 from flask import session
 
 from server import user_db, login_manager
+from server.util.config import get_default_config
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,9 @@ ROLE_TM = 'tm'                              # Topic mapper; includes media and s
 ROLE_STORIES_API = 'stories-api'            # Access to the stories api
 ROLE_SEARCH = 'search'                      # Access to the /search pages
 ROLE_TM_READ_ONLY = 'tm-readonly'           # Topic mapper; excludes media and story editing
+
+# load the config helper
+config = get_default_config()
 
 
 # User class
@@ -142,6 +146,7 @@ def user_admin_mediacloud_client(user_mc_key=None):
     if mc_key_to_use is None:
         mc_key_to_use = user_mediacloud_key()
     user_mc = mediacloud.api.AdminMediaCloud(mc_key_to_use)
+    user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
     return user_mc
 
 
@@ -152,4 +157,5 @@ def user_mediacloud_client(user_mc_key=None):
     if mc_key_to_use is None:
         mc_key_to_use = user_mediacloud_key()
     user_mc = mediacloud.api.MediaCloud(mc_key_to_use)
+    user_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
     return user_mc

--- a/server/util/tags.py
+++ b/server/util/tags.py
@@ -8,6 +8,7 @@ import codecs
 from server import base_dir
 from server.auth import user_mediacloud_client
 from server.cache import cache
+from server.util.config import get_default_config
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,9 @@ VALID_METADATA_IDS = [
 ]
 
 TAG_SPIDERED_STORY = 8875452
+
+# load the config helper
+config = get_default_config()
 
 
 def processed_for_themes_query_clause():
@@ -144,6 +148,7 @@ def tags_in_tag_set(mc_api_key, tag_sets_id):
 def tag_set_with_tags(mc_api_key, tag_sets_id, only_public_tags=False, use_file_cache=False):
     # don't need to cache here, because either you are reading from a file, or each page is cached
     local_mc = MediaCloud(mc_api_key)
+    local_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
     if use_file_cache:
         file_name = "tags_in_{}.json".format(tag_sets_id)
         file_path = os.path.join(static_tag_set_cache_dir, file_name)

--- a/server/util/tags.py
+++ b/server/util/tags.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from mediacloud.api import MediaCloud
 from operator import itemgetter
 import json
 import codecs
@@ -147,8 +146,7 @@ def tags_in_tag_set(mc_api_key, tag_sets_id):
 
 def tag_set_with_tags(mc_api_key, tag_sets_id, only_public_tags=False, use_file_cache=False):
     # don't need to cache here, because either you are reading from a file, or each page is cached
-    local_mc = MediaCloud(mc_api_key)
-    local_mc.V2_API_URL = config.get('MEDIA_CLOUD_API_URL')
+    local_mc = user_mediacloud_client(mc_api_key)
     if use_file_cache:
         file_name = "tags_in_{}.json".format(tag_sets_id)
         file_path = os.path.join(static_tag_set_cache_dir, file_name)


### PR DESCRIPTION
Adds the ability to use different mediacloud API backends by specifying a **MEDIA_CLOUD_API_URL** environment variable.
Fixes https://github.com/mediacloud/web-tools/issues/1958