### PR TITLE
Added "dated" to attention chart, disable word comparison if none

### DIFF
--- a/src/components/topic/attention/FocusSetSelectorContainer.js
+++ b/src/components/topic/attention/FocusSetSelectorContainer.js
@@ -18,26 +18,24 @@ const FocusSetSelectorContainer = (props) => {
 
   const linkToNewFoci = `/topics/${topicId}/snapshot/foci`;
   let noneOption = null;
-  if (hideNoneOption !== true) {
+  if (!hideNoneOption) {
     noneOption = (<MenuItem value={NO_FOCAL_SET_SELECTED}><FormattedMessage {...localMessages.noFocalSet} /></MenuItem>);
   }
   let content = null;
   if (focalSets.length > 0) {
     content = (
-      <>
-        <Select
-          value={selectedFocalSetId !== NO_FOCAL_SET_SELECTED ? selectedFocalSetId : focalSets[0].focal_sets_id}
-          onChange={onFocalSetSelected}
-          fullWidth
-          inputProps={{
-            name: 'Selected Media',
-            id: 'select-media-options',
-          }}
-        >
-          {focalSets.map(fs => <MenuItem key={fs.focal_sets_id} value={fs.focal_sets_id}>{fs.name}</MenuItem>)}
-          {noneOption}
-        </Select>
-      </>
+      <Select
+        value={selectedFocalSetId === NO_FOCAL_SET_SELECTED ? focalSets[0].focal_sets_id : selectedFocalSetId }
+        onChange={onFocalSetSelected}
+        fullWidth
+        inputProps={{
+          name: 'Selected Media',
+          id: 'select-media-options',
+        }}
+      >
+        {focalSets.map(fs => <MenuItem key={fs.focal_sets_id} value={fs.focal_sets_id}>{fs.name}</MenuItem>)}
+        {noneOption}
+      </Select>
     );
   } else {
     content = (

--- a/src/components/topic/controlbar/FocusSelector.js
+++ b/src/components/topic/controlbar/FocusSelector.js
@@ -57,6 +57,7 @@ class FocusSelector extends React.Component {
           className="focus-selector"
           value={selectedId || ''}
           fullWidth
+          displayEmpty
           onChange={this.handleFocusChange}
         >
           {foci.map(focus => (

--- a/src/components/topic/words/FociWordComparison.js
+++ b/src/components/topic/words/FociWordComparison.js
@@ -36,6 +36,7 @@ class FociWordComparison extends React.Component {
             window.location = url;
           }}
           label={messages.download}
+          disabled={this.state.focalSetId === undefined || this.state.focalSetId === 0}
         />
       </DataCard>
     );

--- a/src/components/vis/AttentionOverTimeChart.js
+++ b/src/components/vis/AttentionOverTimeChart.js
@@ -29,7 +29,7 @@ const localMessages = {
   storiesPerWeek: { id: 'chart.storiesOverTime.seriesTitle.week', defaultMessage: 'stories/week' },
   storiesPerMonth: { id: 'chart.storiesOverTime.seriesTitle.month', defaultMessage: 'stories/month' },
   totalCount: { id: 'chart.storiesOverTime.totalCount',
-    defaultMessage: 'We have collected {total, plural, =0 {No stories} one {One story} other {{formattedTotal} stories}}.',
+    defaultMessage: 'We have collected {total, plural, =0 {No stories} one {One story} other {{formattedTotal} dated stories}}.',
   },
   yAxisNormalizedTitle: { id: 'chart.storiesOverTime.series.yaxis', defaultMessage: 'percentage of stories' },
   clickForDetails: { id: 'chart.storiesOverTime.clickForDetails', defaultMessage: 'Click for details' },


### PR DESCRIPTION
Very small topic mapper updates:
* added "dated" to attention chart
* disable word comparison if none